### PR TITLE
Add a scheduled CI run

### DIFF
--- a/.github/workflows/regen_cassettes.yml
+++ b/.github/workflows/regen_cassettes.yml
@@ -5,6 +5,14 @@ on:
     branches: [ main ]
   # Allow manual runs through the web UI
   workflow_dispatch:
+  # Add a run every Monday
+  schedule:
+    #        ┌───────── minute (0 - 59)
+    #        │ ┌───────── hour (0 - 23)
+    #        │ │ ┌───────── day of the month (1 - 31)
+    #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
+    - cron: '0 7 * 1 *'  # Every Monday at 07:00 UTC
 
 jobs:
   rerecord:


### PR DESCRIPTION
Fixes https://github.com/sunpy/sunpy-vcr-cassettes/issues/2